### PR TITLE
把变化通知细化了一下，增加个仅成功和仅失败通知

### DIFF
--- a/public/page/setting/weixin.html
+++ b/public/page/setting/weixin.html
@@ -16,9 +16,14 @@
       <div class="layui-form-item">
         <label class="layui-form-label">变化通知</label>
         <div class="layui-input-block">
-          <input type="checkbox" name="notify_on_change" lay-skin="switch" lay-text="ON|OFF">
+          <select name="notify_on_change">
+            <option value="off">每次运行都通知</option>
+            <option value="on">成功数+失败数大于0时通知</option>
+            <option value="only_success">成功数大于0</option>
+            <option value="only_fails">失败数大于0</option>
+          </select>
+          <!-- <input type="checkbox" name="notify_on_change" lay-skin="switch" lay-text="ON|OFF"> -->
         </div>
-        <tip>当成功数+失败数大于0，才发送通知。</tip>
       </div>
       <div class="layui-form-item">
         <div class="layui-input-block">

--- a/src/Reseed/AutoReseed.php
+++ b/src/Reseed/AutoReseed.php
@@ -1064,8 +1064,21 @@ class AutoReseed
             return '';
         }
         // 2. 检查变化通知开关
-        if (!empty($weixin['notify_on_change']) && self::$wechatMsg['reseedSuccess'] === 0 && self::$wechatMsg['reseedError'] === 0) {
-            return '';
+        if (!empty($weixin['notify_on_change'])) {
+            switch ($weixin['notify_on_change']) {
+                case 'on':
+                    if (self::$wechatMsg['reseedSuccess'] === 0 && self::$wechatMsg['reseedError'] === 0) return '';
+                    break;
+                case 'only_success':
+                    if (self::$wechatMsg['reseedSuccess'] === 0) return '';
+                    break;
+                case 'only_fails':
+                    if (self::$wechatMsg['reseedError'] === 0) return '';
+                    break;
+                case 'off':
+                default:
+                    break;
+            }
         }
         $br = PHP_EOL;
         $text = 'IYUU自动辅种-统计报表';

--- a/src/Reseed/MoveTorrent.php
+++ b/src/Reseed/MoveTorrent.php
@@ -312,8 +312,21 @@ class MoveTorrent extends AutoReseed
             return '';
         }
         // 2. 检查变化通知开关
-        if (!empty($weixin['notify_on_change']) && self::$wechatMsg['MoveSuccess'] === 0 && self::$wechatMsg['MoveError'] === 0) {
-            return '';
+        if (!empty($weixin['notify_on_change'])) {
+            switch ($weixin['notify_on_change']) {
+                case 'on':
+                    if (self::$wechatMsg['MoveSuccess'] === 0 && self::$wechatMsg['MoveError'] === 0) return '';
+                    break;
+                case 'only_success':
+                    if (self::$wechatMsg['MoveSuccess'] === 0) return '';
+                    break;
+                case 'only_fails':
+                    if (self::$wechatMsg['MoveError'] === 0) return '';
+                    break;
+                case 'off':
+                default:
+                    break;
+            }
         }
         $br = PHP_EOL;
         $text = 'IYUU转移任务-统计报表';


### PR DESCRIPTION
鉴于最近失败有点多。。。不少iyuu收录的种子，原站已经删掉了，然后就辅种失败了，觉得可以增加一个辅种前使用http HEAD 检测种子存活情况？