### PR TITLE
关于 qbit 4.4 tacker 补丁的一点点修复

### DIFF
--- a/src/Reseed/MoveTorrent.php
+++ b/src/Reseed/MoveTorrent.php
@@ -101,6 +101,7 @@ class MoveTorrent extends AutoReseed
             }
             $qBittorrent_version_lg_4_4 = false;
             if ($v['type'] == 'qBittorrent') {
+                $version = static::getRpc($k)->appVersion();
                 $arr = explode('.', ltrim($version, "v"), 3);
                 if (count($arr) > 2 && ($arr[0] == '4' && $arr[1] >= '4' ||  $arr[0] > '4')) {
                     global $qBittorrent_version_lg_4_4;
@@ -179,7 +180,7 @@ class MoveTorrent extends AutoReseed
                         die("clients_".$k." 的`{$move[$info_hash]['name']}`，种子文件`{$torrentPath}`解析失败，无法完成转移！");
                     }
                     if (empty($parsed_torrent['announce'])) {
-                        if (isset($move[$info_hash]['tracker'])) {
+                        if (isset($move[$info_hash]['tracker']) && !empty($move[$info_hash]['tracker'])) {
                             $parsed_torrent['announce'] = $move[$info_hash]['tracker'];
                         } else {
                             if (!is_file($fast_resumePath)) {


### PR DESCRIPTION
fix: $version
fix: add not empty to $move[$info_hash]['tracker']